### PR TITLE
Convert remaining stream types to return results

### DIFF
--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -1,7 +1,7 @@
 //An example of how to use the `subscribe` function.
 
 use darkredis::ConnectionPool;
-use futures::StreamExt;
+use futures::TryStreamExt;
 use std::time::Duration;
 
 #[cfg(feature = "runtime_async_std")]
@@ -39,14 +39,17 @@ async fn main() {
     //Use the stream to receive the messages. For a real application you might want to spawn a task, in order
     //to always be listening for updates, so you don't miss any.
     messagestream
-        .for_each(|e| async move {
+        .try_for_each(|e| async move {
             println!(
                 "Received a message on channel '{}': {}",
                 String::from_utf8_lossy(&e.channel),
                 String::from_utf8_lossy(&e.message)
             );
+
+            Ok(())
         })
-        .await;
+        .await
+        .unwrap();
 
     //From here you could, for example, spawn a task which only listens for messages and send them along
     //in your program using channels or other methods.

--- a/src/connection/stream.rs
+++ b/src/connection/stream.rs
@@ -4,7 +4,7 @@ use futures::{
     task::{Context, Poll},
     Future, FutureExt, Stream,
 };
-use std::{pin::Pin, sync::Arc};
+use std::{convert::Infallible, pin::Pin, sync::Arc};
 
 #[cfg(feature = "runtime_async_std")]
 use async_std::net::TcpStream;
@@ -89,7 +89,7 @@ impl MessageStream {
 }
 
 impl Stream for MessageStream {
-    type Item = Message;
+    type Item = std::result::Result<Message, Infallible>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         match self.inner.as_mut().poll_next(cx) {
@@ -99,7 +99,7 @@ impl Stream for MessageStream {
                 let channel = result.next().unwrap().unwrap_string();
                 let message = result.next().unwrap().unwrap_string();
                 let output = Message { channel, message };
-                Poll::Ready(Some(output))
+                Poll::Ready(Some(Ok(output)))
             }
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
@@ -123,7 +123,7 @@ impl PMessageStream {
 }
 
 impl Stream for PMessageStream {
-    type Item = PMessage;
+    type Item = std::result::Result<PMessage, Infallible>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
         match self.inner.as_mut().poll_next(cx) {
@@ -138,7 +138,7 @@ impl Stream for PMessageStream {
                     message,
                     pattern,
                 };
-                Poll::Ready(Some(output))
+                Poll::Ready(Some(Ok(output)))
             }
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,

--- a/src/connection/test.rs
+++ b/src/connection/test.rs
@@ -110,7 +110,7 @@ async fn pubsub() {
                     },
                 ];
                 for i in 0..3 {
-                    let result = stream.next().await.unwrap();
+                    let result = stream.next().await.unwrap().unwrap();
                     assert_eq!(result, expected[i]);
                 }
             };
@@ -149,7 +149,7 @@ async fn pubsub_pattern() {
                     channel: receive_channel,
                     pattern,
                 };
-                let result = stream.next().await.unwrap();
+                let result = stream.next().await.unwrap().unwrap();
                 assert_eq!(result, expected);
             };
 


### PR DESCRIPTION
Title pretty much covers it. The motivation is that its impossible to deserialize JSON inside stream `for_each` calls because they can't return results, so you have to unwrap all {se, de}erializations and risk a bad value killing a listener. 

I changed 2 of the stream types to return `Result<Value, Infallible>` so an the automatic trait implementation of `TryStreamExt` would work. `ResponseStream` already returned a Result, so this makes the others somewhat on par now?

Rustdoc for `MessageStream`:
![image](https://user-images.githubusercontent.com/20936452/96381009-794e5080-1155-11eb-9a7d-184aaf662051.png)

Rustdoc for `PMessageStream`: 
![image](https://user-images.githubusercontent.com/20936452/96382049-d77b3380-1155-11eb-857d-3d8bc0f4d858.png)

This is a breaking change to the API, so a `0.8` release may be appropriate. 
